### PR TITLE
Add authentication with access code and optional SSO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,48 @@ cd tanzu-platform-chat
 cf push
 ```
 
+### Authentication
+
+The application requires authentication to access. There are two authentication methods available: access code and SSO. Both can be used simultaneously.
+
+#### Access Code Authentication
+
+By default, the application is protected with an access code. Users enter the code on the login page to gain access.
+
+1. Set the `APP_AUTH_SECRET` environment variable to your desired access code:
+
+```bash
+cf set-env ai-tool-chat APP_AUTH_SECRET my-secret-code
+cf restart ai-tool-chat
+```
+
+If deploying with `manifest.yml`, provide the variable at push time:
+
+```bash
+cf push --var APP_AUTH_SECRET=my-secret-code
+```
+
+If `APP_AUTH_SECRET` is not set, the access code defaults to `changeme`.
+
+#### SSO Authentication (Optional)
+
+Single Sign-On is automatically enabled when a `p-identity` service is bound to the application. The login page will display a "Sign in with SSO" button alongside the access code form.
+
+1. Create a SSO service instance:
+
+```bash
+cf create-service p-identity uaa my-sso
+```
+
+2. Bind the service to your application:
+
+```bash
+cf bind-service ai-tool-chat my-sso
+cf restart ai-tool-chat
+```
+
+The SSO provider is auto-detected from the Cloud Foundry service binding — no additional configuration is required.
+
 ### Binding to Large Language Models (LLM's)
 
 1. Create a service instance that provides chat LLM capabilities:

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,3 +8,4 @@ applications:
     path: target/cf-mcp-client-2.6.0.jar
     env:
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 21.+ } }'
+      APP_AUTH_SECRET: ((APP_AUTH_SECRET))

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,20 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.pivotal.cfenv</groupId>
+			<artifactId>java-cfenv-boot-pivotal-sso</artifactId>
+			<version>3.5.0</version>
+		</dependency>
+
         <dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/frontend/src/app/app.component.html
+++ b/src/main/frontend/src/app/app.component.html
@@ -1,7 +1,7 @@
-<div class="app-container" role="application" aria-label="Tanzu Platform Chat Application">
+<div class="app-container" role="application" aria-label="Tanzu Tool Chat Application">
   <header role="banner">
     <mat-toolbar>
-      <h1 class="app-title">Tanzu Platform Chat</h1>
+      <h1 class="app-title">Tanzu Tool Chat</h1>
       <span style="flex:1 1 auto"></span>
     </mat-toolbar>
   </header>

--- a/src/main/frontend/src/app/bottom-navigation/bottom-navigation.html
+++ b/src/main/frontend/src/app/bottom-navigation/bottom-navigation.html
@@ -33,5 +33,18 @@
         </span>
       </div>
     }
+
+    <div class="bottom-nav-item">
+      <button
+        type="button"
+        class="bottom-nav-button"
+        (click)="onLogout()"
+        aria-label="Sign out">
+        <div class="bottom-nav-button-content">
+          <mat-icon class="bottom-nav-icon" aria-hidden="true">logout</mat-icon>
+          <span class="bottom-nav-label">Sign out</span>
+        </div>
+      </button>
+    </div>
   </div>
 </nav>

--- a/src/main/frontend/src/app/bottom-navigation/bottom-navigation.ts
+++ b/src/main/frontend/src/app/bottom-navigation/bottom-navigation.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from '@angular/core';
-import { NgClass } from '@angular/common';
+import { Component, Input, inject } from '@angular/core';
+import { NgClass, DOCUMENT } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { SidenavService } from '../../services/sidenav.service';
 import { PlatformMetrics } from '../app.component';
@@ -21,6 +21,8 @@ export class BottomNavigationComponent {
     a2aAgents: [],
     memoryType: 'TRANSIENT'
   };
+
+  private readonly doc = inject(DOCUMENT);
 
   constructor(private sidenavService: SidenavService) {}
 
@@ -106,5 +108,13 @@ export class BottomNavigationComponent {
       default:
         return { show: false, color: '', icon: '' };
     }
+  }
+
+  onLogout(): void {
+    const form = this.doc.createElement('form');
+    form.method = 'POST';
+    form.action = '/logout';
+    this.doc.body.appendChild(form);
+    form.submit();
   }
 }

--- a/src/main/frontend/src/app/navigation-rail/navigation-rail.component.css
+++ b/src/main/frontend/src/app/navigation-rail/navigation-rail.component.css
@@ -21,6 +21,15 @@
   align-items: center;
   padding: 8px 0;
   gap: 4px; /* Material Design 3 spacing */
+  flex: 1;
+}
+
+.nav-rail-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px 0;
+  border-top: 1px solid var(--md-sys-color-outline-variant, var(--mat-sys-outline-variant));
 }
 
 .nav-rail-item {

--- a/src/main/frontend/src/app/navigation-rail/navigation-rail.component.html
+++ b/src/main/frontend/src/app/navigation-rail/navigation-rail.component.html
@@ -2,7 +2,7 @@
   <div class="nav-rail-container">
     @for (item of navigationItems; track item.id) {
       <div class="nav-rail-item">
-        <button 
+        <button
           type="button"
           class="nav-rail-button"
           (click)="onNavItemClick(item.id)"
@@ -10,21 +10,38 @@
           matTooltipPosition="left"
           [attr.aria-label]="item.tooltip"
           [attr.data-nav-item]="item.id">
-          
+
           <div class="nav-rail-button-content">
             <!-- Main icon with status color -->
-            <mat-icon 
-              class="nav-rail-icon" 
+            <mat-icon
+              class="nav-rail-icon"
               [ngClass]="getStatusIndicator(item.id).show ? getStatusIndicator(item.id).color : ''"
               [attr.aria-hidden]="true">
               {{ item.icon }}
             </mat-icon>
           </div>
-          
+
           <!-- Label -->
           <span class="nav-rail-label">{{ item.label }}</span>
         </button>
       </div>
     }
+  </div>
+
+  <div class="nav-rail-footer">
+    <div class="nav-rail-item">
+      <button
+        type="button"
+        class="nav-rail-button"
+        (click)="onLogout()"
+        matTooltip="Sign out"
+        matTooltipPosition="left"
+        aria-label="Sign out">
+        <div class="nav-rail-button-content">
+          <mat-icon class="nav-rail-icon" aria-hidden="true">logout</mat-icon>
+        </div>
+        <span class="nav-rail-label">Sign out</span>
+      </button>
+    </div>
   </div>
 </nav>

--- a/src/main/frontend/src/app/navigation-rail/navigation-rail.component.ts
+++ b/src/main/frontend/src/app/navigation-rail/navigation-rail.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from '@angular/core';
-import { NgClass } from '@angular/common';
+import { Component, Input, inject } from '@angular/core';
+import { NgClass, DOCUMENT } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 import { SidenavService } from '../../services/sidenav.service';
@@ -22,6 +22,8 @@ export class NavigationRailComponent {
     a2aAgents: [],
     memoryType: 'TRANSIENT'
   };
+
+  private readonly doc = inject(DOCUMENT);
 
   constructor(private sidenavService: SidenavService) {}
 
@@ -112,5 +114,14 @@ export class NavigationRailComponent {
       default:
         return { show: false, color: '', icon: '' };
     }
+  }
+
+  onLogout(): void {
+    // POST to /logout then redirect to login page
+    const form = this.doc.createElement('form');
+    form.method = 'POST';
+    form.action = '/logout';
+    this.doc.body.appendChild(form);
+    form.submit();
   }
 }

--- a/src/main/frontend/src/chatbox/chatbox.component.css
+++ b/src/main/frontend/src/chatbox/chatbox.component.css
@@ -47,12 +47,33 @@
   flex-grow: 1;
   margin-bottom: var(--md-spacing-3); /* 12px using Material spacing */
   padding: var(--md-spacing-4); /* Increased padding for better visual separation */
-  scroll-behavior: smooth;
   scrollbar-width: thin;
   scrollbar-color: var(--md-sys-color-outline-variant) transparent;
   background-color: var(--md-sys-color-surface-dim);
   border-radius: var(--md-spacing-3); /* 12px rounded corners */
   border: 1px solid var(--md-sys-color-outline-variant);
+  position: relative; /* For positioning the scroll-to-bottom button */
+}
+
+/* Scroll to bottom floating action button */
+.scroll-to-bottom-fab {
+  position: sticky;
+  bottom: var(--md-spacing-4);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  opacity: 0.9;
+  box-shadow: var(--md-sys-elevation-3dp);
+  transition:
+    opacity var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
+    transform var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-emphasized);
+  animation: md-slide-in-from-bottom var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-emphasized-decelerate);
+}
+
+.scroll-to-bottom-fab:hover {
+  opacity: 1;
+  transform: translateX(-50%) scale(1.1);
+  box-shadow: var(--md-sys-elevation-4dp);
 }
 
 .chatbox-messages::-webkit-scrollbar {

--- a/src/main/frontend/src/chatbox/chatbox.component.html
+++ b/src/main/frontend/src/chatbox/chatbox.component.html
@@ -96,6 +96,16 @@
         </mat-card>
       </div>
     }
+
+    @if (userHasScrolledUp() && isStreaming()) {
+      <button mat-mini-fab
+              color="primary"
+              class="scroll-to-bottom-fab"
+              (click)="scrollToBottomAndResume()"
+              aria-label="Scroll to bottom">
+        <mat-icon>arrow_downward</mat-icon>
+      </button>
+    }
   </div>
   <div class="chatbox-footer" role="form" aria-label="Send message">
     <ng-form class="chat-input-container">

--- a/src/main/frontend/src/chatbox/chatbox.component.ts
+++ b/src/main/frontend/src/chatbox/chatbox.component.ts
@@ -1,13 +1,13 @@
 import {
-  afterNextRender,
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
   Inject,
   Injector,
   Input,
+  NgZone,
   OnDestroy,
-  runInInjectionContext,
   ViewChild,
   signal,
   computed,
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {HttpParams, HttpClient} from '@angular/common/http';
-import {MatFabButton} from '@angular/material/button';
+import {MatFabButton, MatMiniFabButton} from '@angular/material/button';
 import {FormsModule} from '@angular/forms';
 import {MatFormField} from '@angular/material/form-field';
 import {MatInput, MatInputModule} from '@angular/material/input';
@@ -69,12 +69,12 @@ interface StatusUpdate {
 @Component({
   selector: 'app-chatbox',
   standalone: true,
-  imports: [FormsModule, MatFormField, MatInput, MatCard, MatCardContent, MarkdownComponent, MatInputModule, MatIconModule, MatFabButton, TextFieldModule, MatTooltip, MatExpansionModule],
+  imports: [FormsModule, MatFormField, MatInput, MatCard, MatCardContent, MarkdownComponent, MatInputModule, MatIconModule, MatFabButton, MatMiniFabButton, TextFieldModule, MatTooltip, MatExpansionModule],
   templateUrl: './chatbox.component.html',
   styleUrl: './chatbox.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ChatboxComponent implements OnDestroy {
+export class ChatboxComponent implements OnDestroy, AfterViewInit {
   @Input() documentIds: string[] = [];
 
   @Input() set metrics(value: PlatformMetrics) {
@@ -100,9 +100,15 @@ export class ChatboxComponent implements OnDestroy {
   private readonly _isStreaming = signal<boolean>(false);
   private readonly _isConnecting = signal<boolean>(false);
 
+  // Scroll tracking signals
+  private readonly _userHasScrolledUp = signal<boolean>(false);
+  private readonly scrollThreshold = 100; // pixels from bottom to consider "at bottom"
+
   // Public readonly signals
   readonly messages = this._messages.asReadonly();
   readonly chatMessage = this._chatMessage.asReadonly();
+  readonly userHasScrolledUp = this._userHasScrolledUp.asReadonly();
+  readonly isStreaming = this._isStreaming.asReadonly();
 
   // Computed signals for derived state
   readonly canSendMessage = computed(() =>
@@ -201,6 +207,7 @@ export class ChatboxComponent implements OnDestroy {
     reasoningContent: string;
     typing: boolean;
   } | null = null;
+  private scrollListenerCleanup?: () => void;
 
   @ViewChild("chatboxMessages") private chatboxMessages?: ElementRef<HTMLDivElement>;
 
@@ -208,7 +215,8 @@ export class ChatboxComponent implements OnDestroy {
     private injector: Injector,
     @Inject(DOCUMENT) private document: Document,
     private dialog: MatDialog,
-    private http: HttpClient
+    private http: HttpClient,
+    private ngZone: NgZone
   ) {
     // Set up host and protocol
     if (this.document.location.hostname === 'localhost') {
@@ -222,11 +230,15 @@ export class ChatboxComponent implements OnDestroy {
     this.setupEffects();
   }
   
+  ngAfterViewInit(): void {
+    this.setupScrollListener();
+  }
+
   ngOnDestroy(): void {
     if (this.updateBatchTimeout) {
       clearTimeout(this.updateBatchTimeout);
     }
-    
+
     // Flush any pending update before destroying
     if (this.pendingUpdate) {
       this.immediateUpdateMessage(
@@ -235,16 +247,44 @@ export class ChatboxComponent implements OnDestroy {
         this.pendingUpdate.typing
       );
     }
+
+    // Clean up scroll listener
+    if (this.scrollListenerCleanup) {
+      this.scrollListenerCleanup();
+    }
+  }
+
+  private setupScrollListener(): void {
+    if (!this.chatboxMessages) return;
+
+    const element = this.chatboxMessages.nativeElement;
+    const handleScroll = () => {
+      const isNearBottom = element.scrollHeight - element.scrollTop - element.clientHeight < this.scrollThreshold;
+      // Only update if the value changes to avoid unnecessary signal updates
+      if (this._userHasScrolledUp() !== !isNearBottom) {
+        this._userHasScrolledUp.set(!isNearBottom);
+      }
+    };
+
+    // Run outside Angular zone for performance (scroll events fire frequently)
+    this.ngZone.runOutsideAngular(() => {
+      element.addEventListener('scroll', handleScroll, { passive: true });
+    });
+
+    this.scrollListenerCleanup = () => {
+      element.removeEventListener('scroll', handleScroll);
+    };
   }
 
   private setupEffects(): void {
-    // Optimized auto-scroll - only trigger on message count changes, not content changes
+    // Auto-scroll effect - scrolls during streaming if user hasn't scrolled up
     effect(() => {
       const messageCount = this._messages().length;
       const lastBotIndex = this.lastBotMessageIndex();
-      
-      if (messageCount > 0) {
-        // Only scroll if we have a new message or the last bot message finished typing
+      const userScrolledUp = this._userHasScrolledUp();
+
+      if (messageCount > 0 && !userScrolledUp) {
+        // Scroll on new messages or when streaming completes
         const lastBot = lastBotIndex >= 0 ? this._messages()[lastBotIndex] : null;
         if (!lastBot?.typing) {
           // Use requestAnimationFrame for better performance
@@ -703,6 +743,11 @@ export class ChatboxComponent implements OnDestroy {
           this.pendingUpdate.typing
         );
         this.pendingUpdate = null;
+
+        // Auto-scroll during streaming if user hasn't scrolled up
+        if (!this._userHasScrolledUp()) {
+          requestAnimationFrame(() => this.scrollChatToBottom());
+        }
       }
       this.updateBatchTimeout = undefined;
     }, 16); // ~60fps update rate
@@ -863,18 +908,15 @@ export class ChatboxComponent implements OnDestroy {
     });
   }
 
+  scrollToBottomAndResume(): void {
+    this._userHasScrolledUp.set(false);
+    this.scrollChatToBottom();
+  }
+
   private scrollChatToBottom(): void {
-    runInInjectionContext(this.injector, () => {
-      afterNextRender({
-        read: () => {
-          if (this.chatboxMessages) {
-            this.chatboxMessages.nativeElement.lastElementChild?.scrollIntoView({
-              behavior: "smooth",
-              block: "start"
-            });
-          }
-        }
-      });
-    });
+    if (this.chatboxMessages) {
+      const element = this.chatboxMessages.nativeElement;
+      element.scrollTop = element.scrollHeight;
+    }
   }
 }

--- a/src/main/frontend/src/document-panel/document-panel.component.css
+++ b/src/main/frontend/src/document-panel/document-panel.component.css
@@ -42,6 +42,32 @@ mat-sidenav {
   background-color: var(--md-sys-color-surface);
 }
 
+/* Scrollable container for sidenav content */
+.sidenav-scroll-container {
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: var(--md-sys-color-outline-variant) transparent;
+}
+
+.sidenav-scroll-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+.sidenav-scroll-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sidenav-scroll-container::-webkit-scrollbar-thumb {
+  background-color: var(--md-sys-color-outline-variant);
+  border-radius: 3px;
+}
+
+.sidenav-scroll-container::-webkit-scrollbar-thumb:hover {
+  background-color: var(--md-sys-color-outline);
+}
+
 /* Add padding to sidenav content to align with navigation rail */
 mat-sidenav .sidenav-header,
 mat-sidenav .upload-container,
@@ -254,8 +280,7 @@ mat-sidenav .sidenav-header {
 
 /* Documents List */
 .documents-list {
-  overflow-y: auto;
-  max-height: calc(100vh - 400px);
+  /* Documents list no longer needs overflow - parent sidenav-scroll-container handles scrolling */
 }
 
 .documents-list-header {

--- a/src/main/frontend/src/document-panel/document-panel.component.html
+++ b/src/main/frontend/src/document-panel/document-panel.component.html
@@ -1,5 +1,6 @@
 <mat-sidenav-container class="sidenav-container">
   <mat-sidenav #sidenav mode="over" position="end" (openedChange)="onSidenavOpenedChange($event)">
+    <div #sidenavContent class="sidenav-scroll-container">
     <div class="sidenav-header">
       <h2 id="documents-panel-heading">Documents</h2>
       <button mat-icon-button (click)="toggleSidenav()" aria-label="Close documents panel">
@@ -214,11 +215,11 @@
     }
 
     <!-- Advanced Options Section -->
-    <section aria-labelledby="advanced-options-heading" class="advanced-section">
-      <mat-expansion-panel 
+    <section #advancedSection aria-labelledby="advanced-options-heading" class="advanced-section">
+      <mat-expansion-panel
         [expanded]="isAdvancedSectionExpanded()"
-        (opened)="isAdvancedSectionExpanded.set(true)"
-        (closed)="isAdvancedSectionExpanded.set(false)"
+        (opened)="onAdvancedSectionOpened()"
+        (closed)="onAdvancedSectionClosed()"
         class="advanced-expansion-panel">
         <mat-expansion-panel-header>
           <mat-panel-title id="advanced-options-heading">
@@ -284,6 +285,7 @@
         </div>
       </mat-expansion-panel>
     </section>
+    </div>
   </mat-sidenav>
 
   <mat-sidenav-content>

--- a/src/main/frontend/src/document-panel/document-panel.component.ts
+++ b/src/main/frontend/src/document-panel/document-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Inject, Input, Output, ViewChild, AfterViewInit, signal, computed } from '@angular/core';
+import { Component, EventEmitter, Inject, Input, Output, ViewChild, ElementRef, AfterViewInit, signal, computed } from '@angular/core';
 import { HttpClient, HttpEventType } from '@angular/common/http';
 import { DOCUMENT } from '@angular/common';
 import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
@@ -81,6 +81,8 @@ export class DocumentPanelComponent implements AfterViewInit {
   isManualMode = computed(() => this.manualDocumentId().trim().length > 0);
 
   @ViewChild('sidenav') sidenav!: MatSidenav;
+  @ViewChild('advancedSection') advancedSection?: ElementRef<HTMLElement>;
+  @ViewChild('sidenavContent') sidenavContent?: ElementRef<HTMLElement>;
 
   constructor(
     private httpClient: HttpClient,
@@ -388,8 +390,19 @@ export class DocumentPanelComponent implements AfterViewInit {
     this.emitCurrentDocumentIds();
   }
 
-  toggleAdvancedSection(): void {
-    this.isAdvancedSectionExpanded.set(!this.isAdvancedSectionExpanded());
+  onAdvancedSectionOpened(): void {
+    this.isAdvancedSectionExpanded.set(true);
+    // Scroll the advanced section into view after expansion animation
+    setTimeout(() => {
+      this.advancedSection?.nativeElement?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end'
+      });
+    }, 150); // Wait for expansion animation to start
+  }
+
+  onAdvancedSectionClosed(): void {
+    this.isAdvancedSectionExpanded.set(false);
   }
 
   // Helper method to emit the appropriate document IDs based on current mode

--- a/src/main/frontend/src/index.html
+++ b/src/main/frontend/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Tanzu Platform Chat</title>
+  <title>Tanzu Tool Chat</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/src/main/java/org/tanzu/mcpclient/auth/AuthController.java
+++ b/src/main/java/org/tanzu/mcpclient/auth/AuthController.java
@@ -1,0 +1,74 @@
+package org.tanzu.mcpclient.auth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    @Autowired(required = false)
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+    @GetMapping("/status")
+    public Map<String, Object> getAuthStatus(
+            @AuthenticationPrincipal Object principal) {
+        Map<String, Object> status = new HashMap<>();
+
+        if (principal instanceof OAuth2User oAuth2User) {
+            status.put("authenticated", true);
+            status.put("username", oAuth2User.getName());
+            status.put("email", oAuth2User.getAttribute("email"));
+            String displayName = oAuth2User.getAttribute("name");
+            if (displayName == null) {
+                displayName = oAuth2User.getAttribute("given_name");
+            }
+            status.put("displayName", displayName);
+        } else if (principal instanceof UserDetails userDetails) {
+            status.put("authenticated", true);
+            status.put("username", userDetails.getUsername());
+            status.put("email", null);
+            status.put("displayName", userDetails.getUsername());
+        } else {
+            status.put("authenticated", false);
+        }
+
+        return status;
+    }
+
+    @GetMapping("/provider")
+    public Map<String, Object> getProvider() {
+        Map<String, Object> result = new HashMap<>();
+
+        if (clientRegistrationRepository != null) {
+            // Check for common CF identity provider registration IDs
+            for (String registrationId : new String[]{"sso", "uaa", "pivotal-sso"}) {
+                try {
+                    ClientRegistration registration =
+                            clientRegistrationRepository.findByRegistrationId(registrationId);
+                    if (registration != null) {
+                        result.put("provider", registration.getClientName());
+                        result.put("registrationId", registrationId);
+                        return result;
+                    }
+                } catch (Exception ignored) {
+                    // Registration not found, continue checking
+                }
+            }
+        }
+
+        result.put("provider", null);
+        result.put("registrationId", null);
+        return result;
+    }
+}

--- a/src/main/java/org/tanzu/mcpclient/auth/SecurityConfig.java
+++ b/src/main/java/org/tanzu/mcpclient/auth/SecurityConfig.java
@@ -1,0 +1,86 @@
+package org.tanzu.mcpclient.auth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Autowired(required = false)
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+    @Value("${app.auth.secret}")
+    private String authSecret;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(Customizer.withDefaults())
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/login.html",
+                                "/auth/provider",
+                                "/actuator/health/**",
+                                "/actuator/info",
+                                "/oauth2/**",
+                                "/login/**",
+                                "/favicon.ico",
+                                "/*.js",
+                                "/*.css",
+                                "/*.ico",
+                                "/assets/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form
+                        .loginPage("/login.html")
+                        .loginProcessingUrl("/auth/login")
+                        .defaultSuccessUrl("/", true)
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/login.html")
+                        .permitAll()
+                );
+
+        if (clientRegistrationRepository != null) {
+            http.oauth2Login(oauth2 -> oauth2
+                    .loginPage("/login.html")
+                    .defaultSuccessUrl("/", true)
+            );
+        }
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
+        return new InMemoryUserDetailsManager(
+                User.builder()
+                        .username("user")
+                        .password(passwordEncoder.encode(authSecret))
+                        .roles("USER")
+                        .build()
+        );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,9 @@ logging.level.io.modelcontextprotocol=DEBUG
 
 spring.main.allow-bean-definition-overriding=true
 
+# Authentication
+app.auth.secret=${APP_AUTH_SECRET:changeme}
+
 # Actuator endpoints configuration
 management.endpoints.web.exposure.include=health,metrics
 management.endpoint.health.show-details=when-authorized

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tanzu Tool Chat - Login</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Roboto', sans-serif;
+            background: linear-gradient(135deg, #7c6bc4 0%, #6a7fd2 50%, #8b78d0 100%);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            color: #333;
+        }
+
+        .login-container {
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+            padding: 48px 40px 36px;
+            width: 100%;
+            max-width: 400px;
+        }
+
+        .login-header {
+            text-align: center;
+            margin-bottom: 32px;
+        }
+
+        .login-header .icon-wrapper {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 16px;
+        }
+
+        .login-header .material-icons {
+            font-size: 44px;
+            color: #6a7fd2;
+        }
+
+        .login-header h1 {
+            font-size: 26px;
+            font-weight: 500;
+            color: #222;
+            margin-bottom: 8px;
+        }
+
+        .login-header p {
+            font-size: 14px;
+            color: #666;
+            line-height: 1.5;
+        }
+
+        .form-group {
+            margin-bottom: 16px;
+        }
+
+        .form-group input {
+            width: 100%;
+            padding: 14px 16px;
+            border: 1px solid #ccc;
+            border-radius: 8px;
+            font-size: 15px;
+            font-family: 'Roboto', sans-serif;
+            color: #333;
+            background: #fff;
+            transition: border-color 0.2s, box-shadow 0.2s;
+        }
+
+        .form-group input::placeholder {
+            color: #999;
+        }
+
+        .form-group input:focus {
+            outline: none;
+            border-color: #6a7fd2;
+            box-shadow: 0 0 0 2px rgba(106, 127, 210, 0.2);
+        }
+
+        .btn {
+            width: 100%;
+            padding: 13px 24px;
+            border: none;
+            border-radius: 8px;
+            font-size: 15px;
+            font-family: 'Roboto', sans-serif;
+            font-weight: 500;
+            cursor: pointer;
+            transition: background-color 0.2s, box-shadow 0.2s;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            text-decoration: none;
+        }
+
+        .btn .material-icons {
+            font-size: 20px;
+        }
+
+        .btn-primary {
+            background-color: #6a7fd2;
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background-color: #5a6fc2;
+            box-shadow: 0 4px 12px rgba(106, 127, 210, 0.35);
+        }
+
+        .btn-sso {
+            background-color: #3a3a4a;
+            color: white;
+            margin-top: 0;
+            display: none;
+        }
+
+        .btn-sso:hover {
+            background-color: #2a2a3a;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+        }
+
+        .divider {
+            display: none;
+            align-items: center;
+            margin: 16px 0;
+            color: #aaa;
+            font-size: 13px;
+        }
+
+        .divider::before,
+        .divider::after {
+            content: '';
+            flex: 1;
+            border-bottom: 1px solid #ddd;
+        }
+
+        .divider::before {
+            margin-right: 14px;
+        }
+
+        .divider::after {
+            margin-left: 14px;
+        }
+
+        .error-message {
+            background-color: #fdecea;
+            color: #b71c1c;
+            padding: 12px 16px;
+            border-radius: 8px;
+            font-size: 14px;
+            margin-bottom: 20px;
+            display: none;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .error-message .material-icons {
+            font-size: 20px;
+        }
+
+        .footer {
+            text-align: center;
+            margin-top: 28px;
+            font-size: 12px;
+            color: #999;
+        }
+
+        @media (max-width: 480px) {
+            .login-container {
+                margin: 16px;
+                padding: 36px 24px 28px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <div class="login-header">
+            <div class="icon-wrapper">
+                <span class="material-icons">settings_suggest</span>
+            </div>
+            <h1>Tanzu Tool Chat</h1>
+            <p>Enter the access code to start chatting with your AI agent.</p>
+        </div>
+
+        <div class="error-message" id="errorMessage">
+            <span class="material-icons">error_outline</span>
+            Invalid access code. Please try again.
+        </div>
+
+        <form action="/auth/login" method="POST">
+            <input type="hidden" name="username" value="user">
+            <div class="form-group">
+                <input type="password" id="password" name="password"
+                       placeholder="Access code" required autofocus>
+            </div>
+            <button type="submit" class="btn btn-primary">
+                <span class="material-icons">login</span>
+                Sign in
+            </button>
+        </form>
+
+        <div class="divider" id="divider">or</div>
+
+        <a id="ssoButton" class="btn btn-sso" href="#">
+            <span class="material-icons">badge</span>
+            <span id="ssoLabel">Sign in with SSO</span>
+        </a>
+
+        <div class="footer">Powered by Tanzu Platform</div>
+    </div>
+
+    <script>
+        if (window.location.search.includes('error')) {
+            document.getElementById('errorMessage').style.display = 'flex';
+        }
+
+        fetch('/auth/provider')
+            .then(response => response.json())
+            .then(data => {
+                if (data.provider && data.registrationId) {
+                    document.getElementById('ssoButton').style.display = 'flex';
+                    document.getElementById('ssoButton').href =
+                        '/oauth2/authorization/' + data.registrationId;
+                    document.getElementById('ssoLabel').textContent =
+                        'Sign in with ' + data.provider;
+                    document.getElementById('divider').style.display = 'flex';
+                }
+            })
+            .catch(() => {});
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- **Authentication**: Add Spring Security with dual auth — access code via `APP_AUTH_SECRET` env var (defaults to `changeme`) and optional SSO auto-detected when a `p-identity` service is bound on Cloud Foundry
- **Login page**: Styled standalone HTML page with purple gradient, access code form, and dynamic SSO button
- **Logout**: Sign-out button added to navigation rail (desktop) and bottom navigation (mobile)
- **Rebrand**: Rename app to "Tanzu Tool Chat" across all surfaces (toolbar, page title, login page)
- **README**: Add Authentication section documenting access code and SSO setup

Also includes from prior commits on this branch:
- Fix PDF embedding failures for large files
- Improve chat scrolling during streaming responses
- Fix scrolling for Advanced Options expansion panel in Documents

## Test plan
- [x] `mvn clean package` builds successfully
- [x] `npm test` — all 110 frontend tests pass
- [x] Unauthenticated requests redirect to `/login.html`
- [x] Access code login with correct code grants access (302 -> `/`)
- [x] Invalid access code shows error (302 -> `/login.html?error`)
- [x] `/auth/status` returns `{authenticated: true, displayName: "user"}`
- [x] `/actuator/health` accessible without authentication
- [x] Metrics API accessible when authenticated
- [x] Logout invalidates session and redirects to login
- [x] With `p-identity` bound: `/auth/provider` returns `{provider: "sso", registrationId: "sso"}`
- [x] SSO button redirects to UAA authorize endpoint with correct client ID and callback
- [x] Access code login continues to work alongside SSO

🤖 Generated with [Claude Code](https://claude.com/claude-code)